### PR TITLE
Adjust doc, it's actually a tuple that can be empty

### DIFF
--- a/pydantic_strict_partial/__init__.py
+++ b/pydantic_strict_partial/__init__.py
@@ -21,7 +21,7 @@ def create_partial_model(
 
     :param model: The model class to create a partial model from.
     :param optional_fields: The fields to make optional.
-        If None, all fields will be made optional.
+        If empty, all fields will be made optional.
     :param required_fields: The fields to make required.
         If None, no fields will be made required.
     :param default_value: The default value to use for optional fields.


### PR DESCRIPTION
Thank you for creating this, it's exactly what I need! :star_struck:  I had `pydantic_partial` before and found that it's not suitable for my case.

Here's a little improvement to the docstring: The interpreter makes the `*optional_fields` parameter into a tuple of strings. If none are given it's empty. The actual code is already correct.